### PR TITLE
Add the ability to add/remove params

### DIFF
--- a/extension/application.js
+++ b/extension/application.js
@@ -52,7 +52,10 @@ function reloadURL() {
 	if(rows.length) {
 		rows.each(function(index, row) {
 			var divs = $(row).find('td > div');
-			paramObj[$(divs[0]).html()] = $(divs[1]).html();
+		    	// Ignore blank names but allow blank values
+		    	if($(divs[0]).text().trim() != '') {
+			    paramObj[$(divs[0]).text()] = $(divs[1]).text();
+			}
 		});
 		
 		url = $(".table").attr('data-host') + $.param(paramObj);
@@ -64,6 +67,18 @@ function reloadURL() {
 	}
 }
 
+function constructRow(paramName, paramValue) {
+    	html = "";
+    	paramName = paramName || '';
+    	paramValue = paramValue || '';
+
+    	html += "<tr><td><div contenteditable>" + paramName + "</div></td>";
+    	html += "<td><div contenteditable>" + decodeURIComponent(paramValue) + "</div></td>";    
+    	html += "<td><button type='button' class='btn btn-mini btn-danger'>&times;</button></td></tr>";
+
+    	return html;
+}
+
 function constructTable(url) {
 	var html = "",
 		tmp,
@@ -73,13 +88,14 @@ function constructTable(url) {
 
 	for(var i=0; i<list.length; i++) {
 		tmp = list[i].split('=');
-		html = html + "<tr><td><div contenteditable>" + tmp[0] + "</td></div>";
-		html = html + "<td><div contenteditable>" + decodeURIComponent(tmp[1]) + "</div></td></tr>";
+	    	html += constructRow(tmp[0], tmp[1]);
 	}
 	table.find("tbody").html(html);
 	table.attr("data-host", host);
-	table.show();
+
+        $("#controls").show();    
 }
+
 $('#url').on('keypress paste', function() {
 	clearAlert();
 	realignLayout();
@@ -98,6 +114,15 @@ $('#process').on('click', function() {
 $('#reload').on('click', function() {
 	reloadURL();
 });
+
+$('#add-param').on('click', function() { 
+    	$(".table").append(constructRow());
+});
+
+$('table').on('click', 'td button', function() { 
+	$(this).parents('tr').remove();
+});
+
 function saveURL(url) {
 	window.localStorage.setItem("easyURLParamURL", url);	
 }

--- a/extension/main.html
+++ b/extension/main.html
@@ -17,10 +17,15 @@
 		<button type="button" id="process" class="btn">Process URL</button>
 		<button type="button" id="reload" class="btn">Reload Tab</button>
 	</div>
-	<table class="table table-bordered hide">
-		<thead><tr><th>Param</th><th>Value</th></tr></thead>
-		<tbody></tbody>
-	</table>
+        <div id="controls" class="hide">
+		<table class="table table-bordered">
+			<thead><tr><th>Param</th><th colspan="2">Value</th></tr></thead>
+			<tbody></tbody>
+	        </table>
+                <div>
+	        	<button type="button" id="add-param" class="btn btn-mini btn-info">Add Param</button>
+                </div>
+        </div>
 </body>
 <script src="lib/jquery-1.9.0.js"></script>
 <script src="lib/bootstrap.min.js"></script>

--- a/extension/style/styles.css
+++ b/extension/style/styles.css
@@ -65,6 +65,11 @@ textarea::-webkit-input-placeholder {
 	overflow: hidden;
 }
 
+.table td:last-of-type {
+	text-align: center;
+	width: 5%;
+}
+
 tr>th:first-of-type, tr>td:first-of-type  {
 	max-width: 100px;
 	text-overflow: ellipsis;


### PR DESCRIPTION
Hi, I liked your extension more than [URL Parameters](https://chrome.google.com/webstore/detail/url-parameters/mbnigpeabbgkmbcbhkkbnlidcobbapff) (yours has a better look and feel), but one can't add or remove parameters. With my addition this is now possible. 

I think it's a good idea to allow one to edit the URL's path the same way the params can be edited. Many people use REST and/or SEO URLs, which move the would-be query string to the path.

A couple other suggestions: 
1. Move the `Use window URL` button below the textarea, this will make the URL easier to read. Now it's a little squished. 
2. Always process the current tab's URL when the extension is shown. This saves the user from always having to click `Process URL`. If they want to paste and process their own URL then they should paste it and click `Process URL`, you can't avoid this but you _can_ avoid the former. 
